### PR TITLE
Update package for Laravel 5

### DIFF
--- a/src/Jenssegers/Chef/ChefServiceProvider.php
+++ b/src/Jenssegers/Chef/ChefServiceProvider.php
@@ -18,7 +18,9 @@ class ChefServiceProvider extends ServiceProvider {
      */
     public function boot()
     {
-        $this->package('jenssegers/chef');
+        $this->publishes([
+         __DIR__ . '/../../config/config.php' => config_path('chef.php')
+         ], 'config');
     }
 
     /**
@@ -28,16 +30,15 @@ class ChefServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['chef'] = $this->app->share(function($app)
-        {
+        $this->app['chef'] = $this->app->share(function () {
             // load settings from configuration
-            $server = $app['config']->get('chef::server');
-            $client = $app['config']->get('chef::client');
-            $key = $app['config']->get('chef::key');
-            $version = $app['config']->get('chef::version');
-            $enterprise = $app['config']->get('chef::enterprise');
+            $server     = config('chef.server');
+            $client     = config('chef.client');
+            $key        = config('chef.key');
+            $version    = config('chef.version');
+            $enterprise = config('chef.enterprise');
 
-            return new Chef($server, $client, $key, $version,$enterprise);
+            return new Chef($server, $client, $key, $version, $enterprise);
         });
     }
 
@@ -50,5 +51,4 @@ class ChefServiceProvider extends ServiceProvider {
     {
         return array('Chef');
     }
-
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -11,10 +11,10 @@
 | 'version' = the version of the Chef Server API that is being used
 */
 
-return array(
+return [
     'server'    => 'https://localhost',
     'client'    => 'client',
     'key'       => '/etc/chef/client.pem',
-    'version'   => '0.11.4',
+    'version'   => '12.0.0',
     "enterprise" => false
-);
+];


### PR DESCRIPTION
Hi, small patch to make your package work for Laravel 5 and to default to version 12 of chef.
Before merging this it would probably be a good idea to tag a 1.0 version for L4 and a 2.0 for L5.

Btw, I'm using this package heavily for https://github.com/pelletiermaxime/chef-webui-php, so i'd like to thank you for your great work! =)