### PR TITLE
Sign only path portion of URL

### DIFF
--- a/src/Jenssegers/Chef/Chef.php
+++ b/src/Jenssegers/Chef/Chef.php
@@ -143,7 +143,7 @@ class Chef {
 
 
         // sign the request
-        $this->sign($endpoint, $method, $data, $header);
+        $this->sign($parts['path'], $method, $data, $header);
 
         // initiate curl
         $ch = curl_init();


### PR DESCRIPTION
Chef partial-search's combination of GET params in a POST request causes signing to fail.

`$parts['path']` should reliably contain only the endpoint path and allow signing to be successful regardless of the request structure.

Resolves #14 
