### PR TITLE
Error could be something else than an array

### DIFF
--- a/src/Jenssegers/Chef/Chef.php
+++ b/src/Jenssegers/Chef/Chef.php
@@ -180,7 +180,10 @@ class Chef {
             // throw exception if there was an error
             if ($status != 200 && isset($response->error))
             {
-                $message = reset($response->error);
+                $message = $response->error;
+                if(is_array($response->error)){
+                    $message = reset($response->error);
+                }
                 throw new \Exception($message, $status);
             }
             elseif ($response === null)


### PR DESCRIPTION
When using invalid certificate/user, the 401/403 errors is not an array and trigger a php error.