### PR TITLE
Fix 'Invalid signature for user or client' when passing parameters to an Endpoint.

### DIFF
--- a/src/Jenssegers/Chef/Chef.php
+++ b/src/Jenssegers/Chef/Chef.php
@@ -29,7 +29,7 @@ class Chef {
         $this->key = $key;
         $this->version = $version;
         $this->reportingVersion = $reportingVersion;
-        
+
         // get private key content
         if (file_exists($key))
         {
@@ -141,9 +141,11 @@ class Chef {
             $data = json_encode($data);
         }
 
-
+        // Remove possible parameters from the endpoint
+        // (Otherwise this will cause a Invalid signature)
+        $s_endpoint= explode('?', $endpoint, 2)[0];
         // sign the request
-        $this->sign($endpoint, $method, $data, $header);
+        $this->sign($s_endpoint, $method, $data, $header);
 
         // initiate curl
         $ch = curl_init();
@@ -153,7 +155,7 @@ class Chef {
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-        
+
         // most people are using self-signed certs for chef, so its easiest to just
         // disable ssl verification
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);

--- a/src/Jenssegers/Chef/Chef.php
+++ b/src/Jenssegers/Chef/Chef.php
@@ -143,7 +143,7 @@ class Chef {
 
         // Remove possible parameters from the endpoint
         // (Otherwise this will cause a Invalid signature)
-        $s_endpoint= explode('?', $endpoint, 2)[0];
+        $s_endpoint = parse_url($url, PHP_URL_PATH);
         // sign the request
         $this->sign($s_endpoint, $method, $data, $header);
 


### PR DESCRIPTION
When parameters are passed to the endpoint (something like /organizations/ORG/reports/org/runs/1234-5678?start=0&rows=13) requests get signed with the full URL instead of the base, which causes a 'Invalid signature for user or client'.

This removes the parameters when signing.
