### PR TITLE
Remove Mcrypt dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "ext-curl": "*",
         "ext-json": "*",
-        "ext-mcrypt": "*",
         "ext-openssl": "*",
         "php": ">=5.3.0"
     },

--- a/src/Jenssegers/Chef/Chef.php
+++ b/src/Jenssegers/Chef/Chef.php
@@ -211,7 +211,7 @@ class Chef {
 
         // generate initialization vector
         $size = openssl_cipher_iv_length($method);
-        $iv = mcrypt_create_iv($size, MCRYPT_RAND);
+        $iv = openssl_random_pseudo_bytes($size);
 
         // check if file name was given
         if (file_exists($key))


### PR DESCRIPTION
Swap the mcrypt initialization vector with the related function provided by OpenSSL. The mcrypt extension is deprecated in PHP 7.1 and removed in PHP 7.2. This library already has a requirement for ext-openssl and provides a similar function that is supported for PHP 5 >= 5.3.0, PHP 7.

Related documentation:
http://php.net/manual/en/function.openssl-random-pseudo-bytes.php
http://php.net/manual/en/function.mcrypt-create-iv.php